### PR TITLE
Update river preload path

### DIFF
--- a/panic_button_flutter/lib/services/audio_service.dart
+++ b/panic_button_flutter/lib/services/audio_service.dart
@@ -635,7 +635,7 @@ class AudioService {
   Future<void> _preloadCommonAudio() async {
     try {
       // Preload background music (river is commonly used)
-      final riverPath = 'assets/sounds/music/river.mp3';
+      final riverPath = 'assets/sounds/music/river_new.mp3';
       try {
         await rootBundle.load(riverPath);
       } catch (e) {


### PR DESCRIPTION
## Summary
- fix path in `_preloadCommonAudio` so the river background music preload uses `river_new.mp3`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f5f98e6e88326a120bb585f048061