### PR TITLE
Replace default test with navigation check

### DIFF
--- a/panic_button_flutter/test/widget_test.dart
+++ b/panic_button_flutter/test/widget_test.dart
@@ -1,30 +1,36 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:panic_button_flutter/main.dart';
+import 'package:panic_button_flutter/screens/breath_screen.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  setUpAll(() async {
+    // Initialize Supabase with dummy values to satisfy router checks
+    WidgetsFlutterBinding.ensureInitialized();
+    await Supabase.initialize(
+      url: 'https://example.supabase.co',
+      anonKey: 'test-key',
+    );
+    // Mark initialization complete so the router doesn't redirect to '/'
+    isInitialized = true;
+  });
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+  testWidgets('home screen panic button navigates to breath screen',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+    // Verify the start button is shown on the home screen
+    final startFinder = find.text('EMPEZAR');
+    expect(startFinder, findsOneWidget);
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Tap the panic button and allow navigation to complete
+    await tester.tap(startFinder);
+    await tester.pumpAndSettle();
+
+    // The breathing screen should be displayed after navigation
+    expect(find.byType(BreathScreen), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add widget test verifying that the panic button brings user to the breathing screen

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f5d3dfa008326984ddcf416199f55