### PR TITLE
Limit pattern menu height

### DIFF
--- a/panic_button_flutter/lib/screens/breath_screen.dart
+++ b/panic_button_flutter/lib/screens/breath_screen.dart
@@ -278,18 +278,14 @@ class _BreathScreenState extends ConsumerState<BreathScreen> {
     }
   }
 
-  // Add this function to properly update when selecting a pattern from the sheet
-  void showGoalPatternSheet(BuildContext context) {
+  // Add this function to open the pattern sheet with height constraints
+  void _openGoalPatternSheet(BuildContext context) {
     if (_isDisposed) return;
 
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: Colors.transparent,
-      builder: (context) => const GoalPatternSheet(),
-    ).then((_) {
-      // This will be called when the sheet is closed
-      // We need to update the controller to use the newly selected pattern
+    // Use the shared helper from goal_pattern_sheet.dart so the bottom sheet
+    // never exceeds roughly 70% of the screen height.
+    showGoalPatternSheet(context).then((_) {
+      // Update the controller when the sheet is closed
       if (!_isDisposed) {
         _updateBreathingController();
       }
@@ -529,7 +525,7 @@ class _BreathScreenState extends ConsumerState<BreathScreen> {
         maxWidth: isSmallScreen ? 280 : 350,
       ),
       child: TextButton.icon(
-        onPressed: () => showGoalPatternSheet(context),
+        onPressed: () => _openGoalPatternSheet(context),
         style: Theme.of(context).outlinedButtonTheme.style,
         icon: const Icon(
           Icons.air,
@@ -600,7 +596,7 @@ class _BreathScreenState extends ConsumerState<BreathScreen> {
         );
 
         // Show the pattern selector sheet
-        showGoalPatternSheet(context);
+        _openGoalPatternSheet(context);
         return;
       }
 

--- a/panic_button_flutter/lib/widgets/goal_pattern_sheet.dart
+++ b/panic_button_flutter/lib/widgets/goal_pattern_sheet.dart
@@ -458,14 +458,14 @@ class _GoalPatternSheetState extends ConsumerState<GoalPatternSheet> {
   }
 }
 
-void showGoalPatternSheet(BuildContext context) {
+Future<void> showGoalPatternSheet(BuildContext context) {
   // Get screen dimensions to calculate explicit heights
   final screenHeight = MediaQuery.of(context).size.height;
   final viewPadding = MediaQuery.of(context).viewPadding;
   final availableHeight = screenHeight - viewPadding.top - viewPadding.bottom;
 
   // More reliable approach for modal sheets
-  showModalBottomSheet(
+  return showModalBottomSheet(
     context: context,
     isScrollControlled: true,
     useSafeArea: true,
@@ -473,7 +473,8 @@ void showGoalPatternSheet(BuildContext context) {
     isDismissible: true,
     enableDrag: true,
     constraints: BoxConstraints(
-      maxHeight: availableHeight * 0.65, // Explicit max height
+      // Limit sheet height to ~70% of screen following common UI guidelines
+      maxHeight: availableHeight * 0.7,
     ),
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
@@ -483,8 +484,8 @@ void showGoalPatternSheet(BuildContext context) {
         borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
         child: Container(
           color: Theme.of(context).colorScheme.surface,
-          height: availableHeight *
-              0.43, // Initial height (43% of available screen)
+          // Start slightly over half the screen but allow expansion up to 70%
+          height: availableHeight * 0.6,
           child: const GoalPatternSheet(),
         ),
       );


### PR DESCRIPTION
## Summary
- make the goal pattern modal return a Future so callers can await completion
- limit modal height to about 70% of the screen and open at ~60%
- use the shared modal helper from `GoalPatternSheet` in `BreathScreen`
- rename local helper to `_openGoalPatternSheet`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd45e15708326a6f7f51d750c202c