### PR TITLE
Adjust goal pattern sheet height

### DIFF
--- a/panic_button_flutter/lib/screens/breath_screen.dart
+++ b/panic_button_flutter/lib/screens/breath_screen.dart
@@ -278,23 +278,6 @@ class _BreathScreenState extends ConsumerState<BreathScreen> {
     }
   }
 
-  // Add this function to properly update when selecting a pattern from the sheet
-  void showGoalPatternSheet(BuildContext context) {
-    if (_isDisposed) return;
-
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: Colors.transparent,
-      builder: (context) => const GoalPatternSheet(),
-    ).then((_) {
-      // This will be called when the sheet is closed
-      // We need to update the controller to use the newly selected pattern
-      if (!_isDisposed) {
-        _updateBreathingController();
-      }
-    });
-  }
 
   // Navigate back to the journey screen
   void _navigateToJourney() {

--- a/panic_button_flutter/lib/widgets/goal_pattern_sheet.dart
+++ b/panic_button_flutter/lib/widgets/goal_pattern_sheet.dart
@@ -464,7 +464,11 @@ void showGoalPatternSheet(BuildContext context) {
   final viewPadding = MediaQuery.of(context).viewPadding;
   final availableHeight = screenHeight - viewPadding.top - viewPadding.bottom;
 
-  // More reliable approach for modal sheets
+  // More reliable approach for modal sheets. Material guidelines recommend
+  // limiting modal sheets to around 90% of the available height so that the
+  // underlying content is still partially visible. This prevents the sheet
+  // from feeling like a full-screen takeover while keeping enough room for
+  // content.
   showModalBottomSheet(
     context: context,
     isScrollControlled: true,
@@ -473,7 +477,8 @@ void showGoalPatternSheet(BuildContext context) {
     isDismissible: true,
     enableDrag: true,
     constraints: BoxConstraints(
-      maxHeight: availableHeight * 0.65, // Explicit max height
+      // Do not exceed 90% of the screen height
+      maxHeight: availableHeight * 0.9,
     ),
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
@@ -483,8 +488,10 @@ void showGoalPatternSheet(BuildContext context) {
         borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
         child: Container(
           color: Theme.of(context).colorScheme.surface,
-          height: availableHeight *
-              0.43, // Initial height (43% of available screen)
+          // Start the sheet around half of the screen height so it does not
+          // immediately feel overwhelming. Users can still drag it higher up to
+          // the 90% limit if desired.
+          height: availableHeight * 0.5,
           child: const GoalPatternSheet(),
         ),
       );


### PR DESCRIPTION
## Summary
- remove custom sheet function from `BreathScreen`
- limit the global goal selection sheet to 90% of screen height with a 50% initial height

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe049b0908326a26726f29320e15b